### PR TITLE
Use relative path in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "isla"]
 	path = isla
-	url = git@github.com:rems-project/isla.git
+	url = ../../isla.git


### PR DESCRIPTION
The use of git@github... prevents people without write access from cloning this. You can use a relative path to make it agnostic to the transport.

Note I haven't tested this - I'm pretty sure it needs two `..`'s because of a Git quirk (it's documented somewhere) but definitely worth testing! Bit tricky for me to test though.